### PR TITLE
consolidate by jstat

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,24 @@
+name: Run Gradle on PRs
+on:
+  pull_request:
+  push:
+      branches: [main]
+jobs:
+    prBranch:
+        timeout-minutes: 300
+        strategy:
+            matrix:
+                os: [ubuntu-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-java@v3
+              with:
+                  distribution: temurin
+                  java-version: 11
+
+            - name: Setup Gradle
+              uses: gradle/gradle-build-action@v2
+            - name: Execute Gradle tests
+              run:  ./gradlew test
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.cdsap"
-version = "0.1.0"
+version = "0.1.1"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/io/github/cdsap/jdk/tools/parser/ConsolidateProcesses.kt
+++ b/src/main/kotlin/io/github/cdsap/jdk/tools/parser/ConsolidateProcesses.kt
@@ -11,25 +11,21 @@ class ConsolidateProcesses {
         val processesConsolidated = mutableListOf<Process>()
         val jInfoData = JInfoData().process(jInfoResult)
         val jStatData = JStatData().process(jStatResult)
-        if (jInfoData.size != jStatData.size) {
-            // different number of processes
-            // ignore consolidation
-        } else {
-            jInfoData.forEach {
-                if (jStatData.contains(it.key)) {
-                    processesConsolidated.add(
-                        Process(
-                            pid = it.key,
-                            max = it.value.max.toGigsFromBytes(),
-                            usage = jStatData[it.key]?.usage?.toGigsFromKb()!!,
-                            capacity = jStatData[it.key]?.capacity?.toGigsFromKb()!!,
-                            gcTime = jStatData[it.key]?.gcTime?.toMinutes()!!,
-                            uptime = jStatData[it.key]?.uptime?.toMinutes()!!,
-                            typeGc = it.value.gcType,
-                            typeProcess = typeProcess
-                        )
+
+        jStatData.forEach {
+            if (jInfoData.containsKey(it.key)) {
+                processesConsolidated.add(
+                    Process(
+                        pid = it.key,
+                        max = jInfoData[it.key]?.max?.toGigsFromBytes()!!,
+                        usage = it.value.usage.toGigsFromKb(),
+                        capacity = it.value.capacity.toGigsFromKb(),
+                        gcTime = it.value.gcTime.toMinutes(),
+                        uptime = it.value.uptime.toMinutes(),
+                        typeGc = jInfoData[it.key]?.gcType!!,
+                        typeProcess = typeProcess
                     )
-                }
+                )
             }
         }
         return processesConsolidated

--- a/src/test/kotlin/io/github/cdsap/jdk/tools/parser/ConsolidateProcessesTest.kt
+++ b/src/test/kotlin/io/github/cdsap/jdk/tools/parser/ConsolidateProcessesTest.kt
@@ -1,0 +1,70 @@
+package io.github.cdsap.jdk.tools.parser
+
+import io.github.cdsap.jdk.tools.parser.model.TypeProcess
+import org.junit.Assert.*
+import org.junit.Test
+
+
+class ConsolidateProcessesTest {
+    @Test
+    fun testConsolidate() {
+        val jStatResult = """
+            Timestamp    S0C    S1C    S0U    S1U      EC       EU        OC         OU       MC     MU    CCSC   CCSU   YGC     YGCT    FGC    FGCT    CGC    CGCT     GCT
+                1117.8  0.0   30720.0  0.0   30720.0 1135616.0 755712.0  865280.0   546816.0  195184.0 189433.3 22208.0 20357.8     22    0.682   0      0.000  12      0.070    0.752
+            28743
+        """.trimIndent()
+
+        val jInfoResult = """
+            -XX:+UseParallelGC -XX:MaxHeapSize=536870912
+            28743
+            """.trimIndent()
+
+        val consolidateProcesses = ConsolidateProcesses()
+
+        val consolidatedList = consolidateProcesses.consolidate(jStatResult, jInfoResult, TypeProcess.Gradle)
+
+        assertEquals(1, consolidatedList.size)
+
+        val consolidatedProcess = consolidatedList[0]
+        assertEquals("28743", consolidatedProcess.pid)
+        assertEquals(0.5, consolidatedProcess.max, 0.01)
+        assertEquals(1.27, consolidatedProcess.usage, 0.01)
+        assertEquals(1.94, consolidatedProcess.capacity, 0.01)
+        assertEquals(0.01, consolidatedProcess.gcTime, 0.01)
+        assertEquals(18.63, consolidatedProcess.uptime, 0.01)
+        assertEquals("-XX:+UseParallelGC", consolidatedProcess.typeGc)
+        assertEquals(TypeProcess.Gradle, consolidatedProcess.typeProcess)
+    }
+
+    @Test
+    fun testConsolidateThreeJstatsAndTwoJinfoReturnsOnlyTwoProcesses() {
+        val jStatResult = """
+            Timestamp    S0C    S1C    S0U    S1U      EC       EU        OC         OU       MC     MU    CCSC   CCSU   YGC     YGCT    FGC    FGCT    CGC    CGCT     GCT
+                1117.8  0.0   30720.0  0.0   30720.0 1135616.0 755712.0  865280.0   546816.0  195184.0 189433.3 22208.0 20357.8     22    0.682   0      0.000  12      0.070    0.752
+            28743
+            Timestamp    S0C    S1C    S0U    S1U      EC       EU        OC         OU       MC     MU    CCSC   CCSU   YGC     YGCT    FGC    FGCT    CGC    CGCT     GCT
+                1117.8  0.0   30720.0  0.0   30720.0 1135616.0 755712.0  865280.0   546816.0  195184.0 189433.3 22208.0 20357.8     22    0.682   0      0.000  12      0.070    0.752
+            11111
+            Timestamp    S0C    S1C    S0U    S1U      EC       EU        OC         OU       MC     MU    CCSC   CCSU   YGC     YGCT    FGC    FGCT    CGC    CGCT     GCT
+                1117.8  0.0   30720.0  0.0   30720.0 1135616.0 755712.0  865280.0   546816.0  195184.0 189433.3 22208.0 20357.8     22    0.682   0      0.000  12      0.070    0.752
+            32222
+        """.trimIndent()
+
+        val jInfoResult = """
+            -XX:+UseParallelGC -XX:MaxHeapSize=536870912
+            28743
+            -XX:+UseParallelGC -XX:MaxHeapSize=536870912
+            11111
+            """.trimIndent()
+
+        val consolidateProcesses = ConsolidateProcesses()
+
+        val consolidatedList = consolidateProcesses.consolidate(jStatResult, jInfoResult, TypeProcess.Gradle)
+
+        assertEquals(2, consolidatedList.size)
+
+        assertTrue(consolidatedList.any { it.pid == "28743" })
+        assertTrue(consolidatedList.any { it.pid == "11111" })
+
+    }
+}


### PR DESCRIPTION
Instead of assuming the same number of processes parsed in Jstat and Jinfo operations, we consider jstat as the collection of processes to be iterated